### PR TITLE
Release dev changes to main

### DIFF
--- a/AnMe.user.js
+++ b/AnMe.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         AnMe
 // @author       zjw
-// @version      10.0.6
+// @version      10.0.7
 // @updated      2026-04-15
 // @namespace    https://github.com/Zhu-junwei/AnMe
 // @description  通用多网站多账号切换器
@@ -1337,6 +1337,14 @@
     const separator = url.includes("?") ? "&" : "?";
     return `${url}${separator}_=${Date.now()}`;
   }
+  function formatLocalTimestampForFileName(date = /* @__PURE__ */ new Date()) {
+    const value = date instanceof Date ? date : new Date(date);
+    const pad = (part, length = 2) => String(part).padStart(length, "0");
+    return [
+      `${value.getFullYear()}-${pad(value.getMonth() + 1)}-${pad(value.getDate())}`,
+      `${pad(value.getHours())}-${pad(value.getMinutes())}-${pad(value.getSeconds())}-${pad(value.getMilliseconds(), 3)}`
+    ].join("T");
+  }
   function toRemoteUrl(config) {
     const baseUrl = normalizeBaseUrl(config.url);
     const directory = normalizeDirectory(config.directory);
@@ -1607,7 +1615,7 @@
         }
         const remoteUrl = toRemoteUrl(config);
         const archiveBytes = await encodeBackupPayload(exportObj, constants);
-        const timestamp = (/* @__PURE__ */ new Date()).toISOString().replace(/[:.]/g, "-");
+        const timestamp = formatLocalTimestampForFileName();
         const fileName = `${constants.META.NAME}_Sync_${timestamp}${getBackupExtension(constants)}`;
         await request(config, {
           method: "PUT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anme-userscript",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anme-userscript",
-      "version": "10.0.6",
+      "version": "10.0.7",
       "devDependencies": {
         "esbuild": "^0.25.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anme-userscript",
-  "version": "10.0.6",
+  "version": "10.0.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/userscript.header.txt
+++ b/scripts/userscript.header.txt
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         AnMe
 // @author       zjw
-// @version      10.0.6
+// @version      10.0.7
 // @updated      __BUILD_UPDATED_AT__
 // @namespace    https://github.com/Zhu-junwei/AnMe
 // @description  通用多网站多账号切换器

--- a/src/app/core/webdav.js
+++ b/src/app/core/webdav.js
@@ -96,6 +96,16 @@ function appendCacheBust(url) {
   return `${url}${separator}_=${Date.now()}`;
 }
 
+export function formatLocalTimestampForFileName(date = new Date()) {
+  const value = date instanceof Date ? date : new Date(date);
+  const pad = (part, length = 2) => String(part).padStart(length, '0');
+
+  return [
+    `${value.getFullYear()}-${pad(value.getMonth() + 1)}-${pad(value.getDate())}`,
+    `${pad(value.getHours())}-${pad(value.getMinutes())}-${pad(value.getSeconds())}-${pad(value.getMilliseconds(), 3)}`
+  ].join('T');
+}
+
 function toRemoteUrl(config) {
   const baseUrl = normalizeBaseUrl(config.url);
   const directory = normalizeDirectory(config.directory);
@@ -397,7 +407,7 @@ export function createWebDavMethods({ constants, utils, getUI, getCore }) {
 
       const remoteUrl = toRemoteUrl(config);
       const archiveBytes = await encodeBackupPayload(exportObj, constants);
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const timestamp = formatLocalTimestampForFileName();
       const fileName = `${constants.META.NAME}_Sync_${timestamp}${getBackupExtension(constants)}`;
       await request(config, {
         method: 'PUT',

--- a/tests/webdav.test.js
+++ b/tests/webdav.test.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { formatLocalTimestampForFileName } from '../src/app/core/webdav.js';
+
+test('formatLocalTimestampForFileName uses local date parts without a UTC suffix', () => {
+  const value = formatLocalTimestampForFileName(new Date(2026, 3, 15, 10, 26, 45, 465));
+
+  assert.equal(value, '2026-04-15T10-26-45-465');
+  assert.equal(value.endsWith('Z'), false);
+});


### PR DESCRIPTION
## Summary
- use local timestamps in WebDAV backup filenames so they match local UI time tags more closely
- bump userscript and package version to 10.0.7
- include rebuilt userscript output

## Verification
- npm test
- npm run build